### PR TITLE
Need a space after the : for consistency

### DIFF
--- a/shox96_0_2.c
+++ b/shox96_0_2.c
@@ -767,7 +767,7 @@ if (argv == 2) {
    return 1;
 }
 
-printf("\nElapsed: %lf ms\n", timedifference(tStart, getTimeVal()));
+printf("\nElapsed: %0.3lf ms\n", timedifference(tStart, getTimeVal()));
 
 return 0;
 

--- a/shox96_0_2.c
+++ b/shox96_0_2.c
@@ -767,7 +767,7 @@ if (argv == 2) {
    return 1;
 }
 
-printf("\nElapsed:%lf ms\n", timedifference(tStart, getTimeVal()));
+printf("\nElapsed: %lf ms\n", timedifference(tStart, getTimeVal()));
 
 return 0;
 


### PR DESCRIPTION
The `Decompressed` and `Bytes` headings have a space after the `:`. This adds a space after Elapsed so it's consistent with the other headings.