### PR TITLE
Add SHOX_VERSION to usage, and clean up the text for readability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SRCFILE = shox96_0_2.c
-OUTFILE = shox96_0_2
+OUTFILE = shox96
 
 default:
 	gcc -o $(OUTFILE) $(SRCFILE)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Shox96 is an hybrid encoder (entropy and dictionary).  It works by assigning fix
 To compile, just use `make` or use gcc as follows:
 
 ```sh
-gcc -o shox96_0_2 shox96_0_2.c
+gcc -o shox96 shox96_0_2.c
 ```
 
 # API
@@ -28,14 +28,14 @@ The `lnk_list` is used only when a bunch of strings are compressed for use with 
 To see Shox96 in action, simply try to compress a string:
 
 ```
-./shox96_0_2 "Hello World"
+./shox96 "Hello World"
 ```
 
 To compress and decompress a file, use:
 
 ```
-./shox96_0_2 c <input_file> <compressed_file>
-./shox96_0_2 d <compressed_file> <decompressed_file>
+./shox96 c <input_file> <compressed_file>
+./shox96 d <compressed_file> <decompressed_file>
 ```
 
 Shox96 does not give good ratios compressing files more than 512 bytes.  It can also not be used for compressing binary files.  It is only suitable for compressing Short Strings and small text files in constrained environments such as Arduino and other microcontroller based systems.  It can also be used to store compressed short strings in a database. See below for real-life projects that use Shox96.

--- a/shox96_0_2.c
+++ b/shox96_0_2.c
@@ -16,6 +16,9 @@
  * @author Arundale R.
  *
  */
+
+#define SHOX_VERSION "0.2.0"
+
 #ifdef _MSC_VER
 #include <windows.h>
 #else
@@ -762,13 +765,14 @@ if (argv == 2) {
    printf("\nBytes (Compressed/Original=Savings%%): %ld/%ld=", ctot, len);
    printf("%.2f%%\n", perc);
 } else {
-   printf("Usage: shox96 \"string\"\n");
-   printf("  (or) shox96 <c|d|g|G> <in_file> <out_file>\n");
-   printf("  where c means compress, d means decompress\n");
-   printf("    and g or G means generate header file\n");
-   printf("      (<out_file.h>) from <in_file>[.txt] for Arduino\n");
-   printf("      Use G for additional compression considering\n");
-   printf("        repeating sub-strings (slower).\n");
+   printf("Shox96 Version: %s\n", SHOX_VERSION);
+   printf("---------------------\n");
+   printf("Usage: shox96 \"string\" or shox96 [c,d,g,G] [in_file] [out_file]\n");
+   printf("\n");
+   printf("  c = compress\n");
+   printf("  d = decompress\n");
+   printf("  g = generate C header file\n");
+   printf("  G = generate C header file using additional compression (slower)\n");
    return 1;
 }
 

--- a/shox96_0_2.c
+++ b/shox96_0_2.c
@@ -585,7 +585,7 @@ uint32_t tStart;
 
 tStart = getTimeVal();
 
-if (argv == 4 && strcmp(args[1], "c") == 0) {
+if (argv == 4 && strcmp(args[1], "-c") == 0) {
    tot_len = 0;
    ctot = 0;
    fp = fopen(args[2], "rb");
@@ -620,7 +620,7 @@ if (argv == 4 && strcmp(args[1], "c") == 0) {
    printf("\nBytes (Compressed/Original=Savings%%): %ld/%ld=", ctot, tot_len);
    printf("%.2f%%\n", perc);
 } else
-if (argv == 4 && strcmp(args[1], "d") == 0) {
+if (argv == 4 && strcmp(args[1], "-d") == 0) {
    fp = fopen(args[2], "rb");
    if (fp == NULL) {
       perror(args[2]);
@@ -647,9 +647,9 @@ if (argv == 4 && strcmp(args[1], "d") == 0) {
      }
    } while (bytes_read > 0);
 } else
-if (argv == 4 && (strcmp(args[1], "g") == 0 || 
-      strcmp(args[1], "G") == 0)) {
-   if (strcmp(args[1], "g") == 0)
+if (argv == 4 && (strcmp(args[1], "-g") == 0 || 
+      strcmp(args[1], "-G") == 0)) {
+   if (strcmp(args[1], "-g") == 0)
      to_match_repeats_earlier = 0;
    fp = fopen(args[2], "r");
    if (fp == NULL) {
@@ -767,12 +767,13 @@ if (argv == 2) {
 } else {
    printf("Shox96 Version: %s\n", SHOX_VERSION);
    printf("---------------------\n");
-   printf("Usage: shox96 \"string\" or shox96 [c,d,g,G] [in_file] [out_file]\n");
+   printf("Usage: shox96 \"string\" or shox96 [action] [in_file] [out_file]\n");
    printf("\n");
-   printf("  c = compress\n");
-   printf("  d = decompress\n");
-   printf("  g = generate C header file\n");
-   printf("  G = generate C header file using additional compression (slower)\n");
+   printf("Actions:\n");
+   printf("  -c    compress\n");
+   printf("  -d    decompress\n");
+   printf("  -g    generate C header file\n");
+   printf("  -G    generate C header file using additional compression (slower)\n");
    return 1;
 }
 

--- a/shox96_0_2.c
+++ b/shox96_0_2.c
@@ -17,7 +17,7 @@
  *
  */
 
-#define SHOX_VERSION "0.2.0"
+#define SHOX_VERSION "0.2"
 
 #ifdef _MSC_VER
 #include <windows.h>
@@ -766,7 +766,7 @@ if (argv == 2) {
    printf("%.2f%%\n", perc);
 } else {
    printf("Shox96 (byte format version: %s)\n", SHOX_VERSION);
-   printf("---------------------\n");
+   printf("---------------------------------\n");
    printf("Usage: shox96 \"string\" or shox96 [action] [in_file] [out_file]\n");
    printf("\n");
    printf("Actions:\n");

--- a/shox96_0_2.c
+++ b/shox96_0_2.c
@@ -765,7 +765,7 @@ if (argv == 2) {
    printf("\nBytes (Compressed/Original=Savings%%): %ld/%ld=", ctot, len);
    printf("%.2f%%\n", perc);
 } else {
-   printf("Shox96 Version: %s\n", SHOX_VERSION);
+   printf("Shox96 (byte format version: %s)\n", SHOX_VERSION);
    printf("---------------------\n");
    printf("Usage: shox96 \"string\" or shox96 [action] [in_file] [out_file]\n");
    printf("\n");


### PR DESCRIPTION
This should make the `Shox96` CLI a little more user friendly (and readable)